### PR TITLE
fix(type:token): allow boolean

### DIFF
--- a/src/router.spec.ts
+++ b/src/router.spec.ts
@@ -144,6 +144,17 @@ describe(Router.name, ()=> {
             expect(router.generate('posts', {'_format': 'json'})).toBe('/posts.json');
         });
 
+        it("with boolean token", ()=> {
+            const router = new Router({}, {
+                posts: {
+                    tokens: [['variable', '.', '', '_format', true], ['text', '/posts']],
+                }
+            });
+
+            expect(router.generate('posts')).toBe('/posts');
+            expect(router.generate('posts', {'_format': 'json'})).toBe('/posts.json');
+        });
+
         it("with query string without defautls", ()=> {
             const router = new Router({}, {
                 posts: {

--- a/src/router.ts
+++ b/src/router.ts
@@ -296,7 +296,7 @@ export enum TokenType
     Variable = 'variable',
 }
 
-export type Token = string[]
+export type Token = (string|boolean)[]
 
 export interface ParsedToken
 {


### PR DESCRIPTION
Hi!

I faced a typing issue with `Token` type. 
It seems that it can also be a boolean, but to be honest I don't know why it can be the case and I don't really have time for this.

 ![2020-10-14_20-43](https://user-images.githubusercontent.com/2103975/96032492-098f4b80-0e5f-11eb-8faf-ebd681d3ac08.png)
![2020-10-14_20-42](https://user-images.githubusercontent.com/2103975/96032493-0a27e200-0e5f-11eb-8ea5-63f74843ca6c.png)

Thanks